### PR TITLE
Fix error in PHS3000.thermoelectricity.read_data

### DIFF
--- a/monashspa/PHS3000/thermoelectricity.py
+++ b/monashspa/PHS3000/thermoelectricity.py
@@ -43,7 +43,7 @@ def read_data(filepath):
     f = np.vectorize(lambda x: x.total_seconds())
 
     # calculate the timedelta column
-    time_delta[1:] = f(arr[1:,0]-arr[0,0])
+    time_delta[1:] = f(arr[1:,0]-np.array(arr[0,0]))
 
     # insert the timedelta column at column 1
     arr = np.insert(arr, 1, time_delta, axis=1)


### PR DESCRIPTION
Previously, a TypeError (unsupported operand type(s) for -: 'numpy.ndarray' and 'Timestamp') would be raised when attempting to use the monashspa.PHS3000.thermoelectricity.read_data function to parse the CSV file generated by the PHS3000 thermoelectricity lab software.

I believe this occurs because numpy only knows how to calculate operations between numpy arrays and numpy's/python's own built-in scalars, which pandas.Timestamp is not. To convert a custom scalar data type into one that numpy can handle, we wrap it with the numpy.array function.